### PR TITLE
Updates @lint-todo/utils to latest version for read isolation

### DIFF
--- a/__tests__/__utils__/build-read-options.ts
+++ b/__tests__/__utils__/build-read-options.ts
@@ -1,0 +1,5 @@
+import { ReadTodoOptions } from '@lint-todo/utils';
+
+export function buildReadOptions(): ReadTodoOptions {
+  return { engine: 'eslint', filePath: '' };
+}

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -4,6 +4,7 @@ import { differenceInDays, subDays } from 'date-fns';
 import {
   DaysToDecay,
   DaysToDecayByRule,
+  getTodoConfig,
   getTodoStorageFilePath,
   readTodoData,
   readTodoStorageFile,
@@ -12,6 +13,7 @@ import {
 } from '@lint-todo/utils';
 import { FakeProject } from '../__utils__/fake-project';
 import { getObjectFixture, getStringFixture } from '../__utils__/get-fixture';
+import { buildReadOptions } from '../__utils__/build-read-options';
 import { buildMaybeTodos } from '../../src/formatter';
 
 describe('eslint with todo formatter', function () {
@@ -284,7 +286,7 @@ describe('eslint with todo formatter', function () {
 
     expect(result.exitCode).toEqual(0);
     expect(todoStorageFileExists(project.baseDir)).toEqual(true);
-    expect(readTodoData(project.baseDir).size).toEqual(7);
+    expect(readTodoData(project.baseDir, buildReadOptions()).size).toEqual(7);
 
     result = await runEslintWithFormatter();
 
@@ -306,7 +308,7 @@ describe('eslint with todo formatter', function () {
 
     expect(result.exitCode).toEqual(0);
     expect(todoStorageFileExists(project.baseDir)).toEqual(true);
-    expect(readTodoData(project.baseDir).size).toEqual(7);
+    expect(readTodoData(project.baseDir, buildReadOptions()).size).toEqual(7);
 
     project.write({
       src: {
@@ -337,7 +339,13 @@ describe('eslint with todo formatter', function () {
         ),
         undefined,
         'ember-template-lint'
-      )
+      ),
+      {
+        engine: 'eslint',
+        filePath: '',
+        todoConfig: getTodoConfig(project.baseDir, 'eslint'),
+        shouldRemove: () => true,
+      }
     );
 
     const result = await runEslintWithFormatter({
@@ -552,7 +560,7 @@ describe('eslint with todo formatter', function () {
           env: { UPDATE_TODO: '1' },
         });
 
-        const todos = readTodoData(project.baseDir);
+        const todos = readTodoData(project.baseDir, buildReadOptions());
 
         expect(result.exitCode).toEqual(0);
 
@@ -582,7 +590,7 @@ describe('eslint with todo formatter', function () {
           env: { UPDATE_TODO: '1', TODO_DAYS_TO_WARN: '30' },
         });
 
-        const todos = readTodoData(project.baseDir);
+        const todos = readTodoData(project.baseDir, buildReadOptions());
 
         expect(result.exitCode).toEqual(0);
 
@@ -612,7 +620,7 @@ describe('eslint with todo formatter', function () {
           env: { UPDATE_TODO: '1' },
         });
 
-        const todos = readTodoData(project.baseDir);
+        const todos = readTodoData(project.baseDir, buildReadOptions());
 
         expect(result.exitCode).toEqual(0);
 
@@ -642,7 +650,7 @@ describe('eslint with todo formatter', function () {
           env: { UPDATE_TODO: '1', TODO_DAYS_TO_ERROR: '30' },
         });
 
-        const todos = readTodoData(project.baseDir);
+        const todos = readTodoData(project.baseDir, buildReadOptions());
 
         expect(result.exitCode).toEqual(0);
 
@@ -673,7 +681,7 @@ describe('eslint with todo formatter', function () {
           env: { UPDATE_TODO: '1' },
         });
 
-        const todos = readTodoData(project.baseDir);
+        const todos = readTodoData(project.baseDir, buildReadOptions());
 
         expect(result.exitCode).toEqual(0);
 
@@ -713,7 +721,7 @@ describe('eslint with todo formatter', function () {
           },
         });
 
-        const todos = readTodoData(project.baseDir);
+        const todos = readTodoData(project.baseDir, buildReadOptions());
 
         expect(result.exitCode).toEqual(0);
 
@@ -1183,7 +1191,7 @@ describe('eslint with todo formatter', function () {
             },
           });
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 

--- a/__tests__/unit/formatter-test.ts
+++ b/__tests__/unit/formatter-test.ts
@@ -6,6 +6,7 @@ import {
 import { DirResult, dirSync } from 'tmp';
 import { buildMaybeTodos, formatter, updateResults } from '../../src/formatter';
 import fixtures from '../__fixtures__/fixtures';
+import { buildReadOptions } from '../__utils__/build-read-options';
 import { deepCopy } from '../__utils__/deep-copy';
 import { setUpdateTodoEnv } from '../__utils__/set-env';
 
@@ -44,7 +45,7 @@ describe('format-results', () => {
 
     expect(todoStorageFileExists(tmpDir.name)).toBe(true);
 
-    const todos = readTodoData(tmpDir.name);
+    const todos = readTodoData(tmpDir.name, buildReadOptions());
 
     expect(todos.size).toEqual(18);
   });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:jest": "yarn build && jest --no-cache"
   },
   "dependencies": {
-    "@lint-todo/utils": "^11.0.0",
+    "@lint-todo/utils": "^12.0.0",
     "chalk": "^4.1.0",
     "ci-info": "^3.3.0",
     "eslint": "^7.10.0",

--- a/src/print-results.ts
+++ b/src/print-results.ts
@@ -10,9 +10,11 @@ import {
   TodoResultMessage,
 } from './types';
 
+type TodoPrintOptions = Omit<TodoFormatterOptions, 'writeTodoOptions'>;
+
 export function printResults(
   results: ESLint.LintResult[],
-  options: TodoFormatterOptions
+  options: TodoPrintOptions
 ): string {
   const counts = sumCounts(results);
 
@@ -40,7 +42,7 @@ export function printResults(
 
 function formatResults(
   results: ESLint.LintResult[],
-  options: TodoFormatterOptions
+  options: TodoPrintOptions
 ): string {
   let output = '';
 
@@ -68,7 +70,7 @@ function formatResults(
 
 function formatMessages(
   messages: TodoResultMessage[],
-  options: TodoFormatterOptions
+  options: TodoPrintOptions
 ): string {
   const messageRows = messages
     .filter(
@@ -112,10 +114,7 @@ function formatMessages(
     : '';
 }
 
-function formatSummary(
-  counts: TodoFormatterCounts,
-  options: TodoFormatterOptions
-) {
+function formatSummary(counts: TodoFormatterCounts, options: TodoPrintOptions) {
   let output = '';
 
   const { includeTodo } = options;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -27,7 +27,7 @@ export interface TodoFormatterOptions {
   includeTodo: boolean;
   shouldCleanTodos: boolean;
   todoInfo: TodoInfo;
-  writeTodoOptions: Partial<WriteTodoOptions>;
+  writeTodoOptions: WriteTodoOptions;
 }
 
 export interface TodoFormatterCounts {

--- a/yarn.lock
+++ b/yarn.lock
@@ -509,10 +509,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@lint-todo/utils@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@lint-todo/utils/-/utils-11.0.0.tgz#adb6f0ba280a45bff2449d548727cbff35714db7"
-  integrity sha512-FwAREUQ0ncD3XDujs34183WjzOeX07KrRwi2AkkIJT2irrTkBPyE9FLs2sjjh+Lnj2OB1d+fDN4BWi9r2Nnt+w==
+"@lint-todo/utils@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@lint-todo/utils/-/utils-12.0.0.tgz#625ae5aa9b93f60a7567a515265af2704bf426a6"
+  integrity sha512-MGIDlAwHS31K26N/Fpt15QopnWSALP8uzCRyKXOpm0PoBuCof6a443wJGLPQlPcqPZUMdf4SjYUgEmleMv3REw==
   dependencies:
     "@types/eslint" "^7.2.13"
     fs-extra "^9.1.0"


### PR DESCRIPTION
The latest version of `@lint-todo/utils` [includes a fix](https://github.com/lint-todo/utils/releases/tag/v12.0.0) for ensuring correct read isolation when reading todo data. This PR updates to that version, and additionally uses a cleaner API for reading todo batches.