### PR TITLE
Adds COMPACT_TODO functionality to compact todo storage file.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,13 +2,14 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint", "jest", "prettier"],
   "extends": [
-    "prettier",
-    "prettier/@typescript-eslint",
+    "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:jest/recommended",
     "plugin:jest/style",
     "plugin:node/recommended",
-    "plugin:unicorn/recommended"
+    "plugin:unicorn/recommended",
+    "prettier/@typescript-eslint",
+    "prettier"
   ],
   "parserOptions": {
     "ecmaVersion": 2018,

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ If you want to opt out of this behavior, you can run with the `NO_CLEAN_TODO` en
 NO_CLEAN_TODO='1' eslint . --format @lint-todo/eslint-formatter-todo
 ```
 
+To compact the `.lint-todo` storage file, you can use the `COMPACT_TODO` environment variable.
+
+```bash
+COMPACT_TODO=1 eslint . --format @lint-todo/eslint-formatter-todo
+```
+
 ### Configuring Due Dates
 
 Todos can be created with optional due dates. These due dates allow for todos to, over a period of time, 'decay' the severity to a **warning** and/or **error** after a certain date. This helps ensure that todos are created but not forgotten, and can allow for better managing incremental roll-outs of large-scale or slow-to-fix rules.

--- a/__tests__/__utils__/get-fixture.ts
+++ b/__tests__/__utils__/get-fixture.ts
@@ -31,7 +31,9 @@ export function getObjectFixture<T extends ESLint.LintResult>(
 
   return updatePaths(
     tmp,
-    fixture.hasOwnProperty('results') ? fixture.results : fixture
+    Object.prototype.hasOwnProperty.call(fixture, 'results')
+      ? fixture.results
+      : fixture
   );
 }
 

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -259,7 +259,7 @@ describe('eslint with todo formatter', function () {
 
     expect(result.exitCode).toEqual(1);
     expect(stdout).toMatch(
-      /1:10  error {4}'sayHi' is defined but never used  no-unused-vars/
+      /1:10 {2}error {4}'sayHi' is defined but never used {2}no-unused-vars/
     );
     expect(stdout).toMatch(/2:3 {3}warning {2}Unexpected alert {19}no-alert/);
     expect(stdout).toMatch(
@@ -375,10 +375,10 @@ describe('eslint with todo formatter', function () {
 
     expect(result.exitCode).toEqual(0);
     expect(stdout).toMatch(
-      /1:10  todo  'addOne' is defined but never used\s+no-unused-vars/
+      /1:10 {2}todo {2}'addOne' is defined but never used\s+no-unused-vars/
     );
     expect(stdout).toMatch(
-      /1:10  todo  'fibonacci' is defined but never used\s+no-unused-vars/
+      /1:10 {2}todo {2}'fibonacci' is defined but never used\s+no-unused-vars/
     );
     expect(stdout).toMatch(/✖ 0 problems \(0 errors, 0 warnings, 10 todos\)/);
   });
@@ -405,10 +405,10 @@ describe('eslint with todo formatter', function () {
 
     expect(result.exitCode).toEqual(0);
     expect(stdout).toMatch(
-      /1:10  todo  'addOne' is defined but never used\s+no-unused-vars/
+      /1:10 {2}todo {2}'addOne' is defined but never used\s+no-unused-vars/
     );
     expect(stdout).toMatch(
-      /1:10  todo  'fibonacci' is defined but never used\s+no-unused-vars/
+      /1:10 {2}todo {2}'fibonacci' is defined but never used\s+no-unused-vars/
     );
     expect(stdout).toMatch(/✖ 0 problems \(0 errors, 0 warnings, 10 todos\)/);
   });
@@ -442,12 +442,12 @@ describe('eslint with todo formatter', function () {
 
     expect(result.exitCode).toEqual(1);
     expect(stdout).toMatch(
-      /1:10  todo  'addOne' is defined but never used\s+no-unused-vars/
+      /1:10 {2}todo {2}'addOne' is defined but never used\s+no-unused-vars/
     );
     expect(stdout).toMatch(
-      /1:10  error    'sayHi' is defined but never used\s+no-unused-vars/
+      /1:10 {2}error {4}'sayHi' is defined but never used\s+no-unused-vars/
     );
-    expect(stdout).toMatch(/2:3   warning  Unexpected alert\s+no-alert/);
+    expect(stdout).toMatch(/2:3 {3}warning {2}Unexpected alert\s+no-alert/);
     expect(stdout).toMatch(/✖ 3 problems \(2 errors, 1 warning, 7 todos\)/);
   });
 
@@ -479,7 +479,7 @@ describe('eslint with todo formatter', function () {
     const results = stripAnsi(result.stdout).trim().split(/\r?\n/);
 
     expect(results[1]).toMatch(
-      /0:0  error  Todo violation passes `no-unused-vars` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list  invalid-todo-violation-rule/
+      /0:0 {2}error {2}Todo violation passes `no-unused-vars` rule. Please run with `CLEAN_TODO=1` env var to remove this todo from the todo list {2}invalid-todo-violation-rule/
     );
     expect(results[3]).toMatch(/✖ 1 problem \(1 error, 0 warnings\)/);
 
@@ -769,25 +769,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(0);
         expect(stdout).toMatch(
-          /1:10  todo  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}todo {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   todo  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}todo {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   todo  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}todo {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  todo  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}todo {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  todo  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}todo {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   todo  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}todo {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   todo  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}todo {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(
           /✖ 0 problems \(0 errors, 0 warnings, 7 todos\)/
@@ -820,25 +820,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(0);
         expect(stdout).toMatch(
-          /1:10  todo  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}todo {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   todo  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}todo {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   todo  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}todo {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  todo  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}todo {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  todo  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}todo {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   todo  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}todo {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   todo  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}todo {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(
           /✖ 0 problems \(0 errors, 0 warnings, 7 todos\)/
@@ -868,25 +868,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(0);
         expect(stdout).toMatch(
-          /1:10  warning  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}warning {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   warning  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}warning {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   warning  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}warning {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  warning  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}warning {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  warning  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}warning {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   warning  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}warning {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   warning  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}warning {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(/✖ 7 problems \(0 errors, 7 warnings\)/);
       });
@@ -911,25 +911,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(0);
         expect(stdout).toMatch(
-          /1:10  warning  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}warning {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   warning  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}warning {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   warning  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}warning {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  warning  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}warning {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  warning  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}warning {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   warning  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}warning {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   warning  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}warning {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(/✖ 7 problems \(0 errors, 7 warnings\)/);
       });
@@ -958,25 +958,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(0);
         expect(stdout).toMatch(
-          /1:10  warning  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}warning {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   warning  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}warning {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   warning  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}warning {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  warning  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}warning {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  warning  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}warning {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   warning  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}warning {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   warning  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}warning {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(/✖ 7 problems \(0 errors, 7 warnings\)/);
       });
@@ -1004,25 +1004,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(1);
         expect(stdout).toMatch(
-          /1:10  error  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}error {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   error  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}error {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   error  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}error {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  error  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}error {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  error  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}error {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   error  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}error {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   error  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}error {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(/✖ 7 problems \(7 errors, 0 warnings\)/);
       });
@@ -1047,25 +1047,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(1);
         expect(stdout).toMatch(
-          /1:10  error  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}error {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   error  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}error {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   error  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}error {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  error  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}error {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  error  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}error {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   error  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}error {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   error  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}error {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(/✖ 7 problems \(7 errors, 0 warnings\)/);
       });
@@ -1094,25 +1094,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(1);
         expect(stdout).toMatch(
-          /1:10  error  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}error {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   error  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}error {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   error  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}error {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  error  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}error {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  error  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}error {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   error  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}error {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   error  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}error {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(/✖ 7 problems \(7 errors, 0 warnings\)/);
       });
@@ -1138,25 +1138,25 @@ describe('eslint with todo formatter', function () {
 
         expect(result.exitCode).toEqual(1);
         expect(stdout).toMatch(
-          /1:10  error  'addOne' is defined but never used\s+no-unused-vars/
+          /1:10 {2}error {2}'addOne' is defined but never used\s+no-unused-vars/
         );
         expect(stdout).toMatch(
-          /2:7   error  Use the isNaN function to compare with NaN\s+use-isnan/
+          /2:7 {3}error {2}Use the isNaN function to compare with NaN\s+use-isnan/
         );
         expect(stdout).toMatch(
-          /2:9   error  Expected '!==' and instead saw '!='\s+eqeqeq/
+          /2:9 {3}error {2}Expected '!==' and instead saw '!='\s+eqeqeq/
         );
         expect(stdout).toMatch(
-          /3:12  error  Unary operator '\+\+' used\s+no-plusplus/
+          /3:12 {2}error {2}Unary operator '\+\+' used\s+no-plusplus/
         );
         expect(stdout).toMatch(
-          /3:12  error  Assignment to function parameter 'i'\s+no-param-reassign/
+          /3:12 {2}error {2}Assignment to function parameter 'i'\s+no-param-reassign/
         );
         expect(stdout).toMatch(
-          /5:3   error  Function 'addOne' expected a return value\s+consistent-return/
+          /5:3 {3}error {2}Function 'addOne' expected a return value\s+consistent-return/
         );
         expect(stdout).toMatch(
-          /5:3   error  Unnecessary return statement\s+no-useless-return/
+          /5:3 {3}error {2}Unnecessary return statement\s+no-useless-return/
         );
         expect(stdout).toMatch(/✖ 7 problems \(7 errors, 0 warnings\)/);
       });

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -517,7 +517,9 @@ describe('eslint with todo formatter', function () {
       },
     });
 
-    const result = await runEslintWithFormatter();
+    // normally we wouldn't need to use the --fix flag, since todos are auto-cleaned. Auto cleaning by default isn't
+    // enabled in CI, however, so we need to force the fix in order to mimic the default behavior.
+    const result = await runEslintWithFormatter(['--fix']);
 
     expect(result.exitCode).toEqual(0);
 

--- a/__tests__/acceptance/eslint-with-todo-formatter-test.ts
+++ b/__tests__/acceptance/eslint-with-todo-formatter-test.ts
@@ -498,6 +498,53 @@ describe('eslint with todo formatter', function () {
     expect(todoContents).toHaveLength(2);
   });
 
+  it('can compact todo storage file', async function () {
+    project.write({
+      src: {
+        'with-fixable-error.js': getStringFixture('with-fixable-error.js'),
+      },
+    });
+
+    // generate todo based on existing error
+    await runEslintWithFormatter({
+      env: { UPDATE_TODO: '1' },
+    });
+
+    // mimic fixing the error manually via user interaction
+    project.write({
+      src: {
+        'with-fixable-error.js': getStringFixture('no-errors.js'),
+      },
+    });
+
+    const result = await runEslintWithFormatter();
+
+    expect(result.exitCode).toEqual(0);
+
+    expect(readTodoStorageFile(getTodoStorageFilePath(project.baseDir)))
+      .toMatchInlineSnapshot(`
+      Array [
+        "add|eslint|no-unused-vars|1|10|1|16|50f2c7b9dac0a4af1cde42fe5be7963201d0504d|1639526400000|1642118400000|1644710400000|src/with-fixable-error.js",
+        "remove|eslint|no-unused-vars|1|10|1|16|50f2c7b9dac0a4af1cde42fe5be7963201d0504d|1639526400000|1642118400000|1644710400000|src/with-fixable-error.js",
+      ]
+    `);
+
+    await runEslintWithFormatter({
+      env: {
+        COMPACT_TODO: '1',
+      },
+    });
+
+    expect(readTodoStorageFile(getTodoStorageFilePath(project.baseDir)))
+      .toMatchInlineSnapshot(`
+      Array [
+        "add|eslint|no-unused-vars|1|10|1|16|50f2c7b9dac0a4af1cde42fe5be7963201d0504d|1639526400000|1642118400000|1644710400000|src/with-fixable-error.js",
+      ]
+    `);
+
+    expect(result.exitCode).toEqual(0);
+  });
+
   for (const { name, isLegacy, setTodoConfig } of [
     {
       name: 'Shorthand todo configuration',

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,6 +1,7 @@
 import {
   applyTodoChanges,
   buildTodoDatum,
+  compactTodoStorageFile,
   generateTodoBatches,
   getSeverity,
   getTodoConfig,
@@ -30,6 +31,12 @@ export function formatter(results: ESLint.LintResult[]): string {
 
   if (!todoConfigResult.isValid) {
     throw new Error(todoConfigResult.message);
+  }
+
+  if (process.env.COMPACT_TODO) {
+    const { compacted } = compactTodoStorageFile(baseDir);
+
+    return `Removed ${compacted} todos in .lint-todo storage file`;
   }
 
   const todoInfo = {

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -31,7 +31,7 @@ export function formatter(results: ESLint.LintResult[]): string {
   if (!todoConfigResult.isValid) {
     throw new Error(todoConfigResult.message);
   }
-  debugger;
+
   const todoInfo = {
     added: 0,
     removed: 0,


### PR DESCRIPTION
This PR leverages the `compactTodoStorageFile` function within `@lint-todo/utils` to surface the capability to compact the todo storage file. 

In order to use it:

```
COMPACT_TODO='1' eslint . -f @lint-todo/eslint-formatter-todo
```

This will ensure the `.lint-todo` storage file only represents active todos.